### PR TITLE
Update commander to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@typescript-eslint/eslint-plugin": "^4.6.0",
     "@typescript-eslint/parser": "^4.6.0",
     "apng2gif": "^1.7.0",
-    "commander": "^6.0.0",
+    "commander": "^7.0.0",
     "eslint": "^7.6.0",
     "eslint-config-prettier": "^7.0.0",
     "eslint-plugin-prettier": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -357,10 +357,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-6.0.0.tgz#2b270da94f8fb9014455312f829a1129dbf8887e"
-  integrity sha512-s7EA+hDtTYNhuXkTlhqew4txMZVdszBmKWSPEMxGr8ru8JXR7bLUFIAtPhcSuFdJQ0ILMxnJi8GkQL0yvDy/YA==
+commander@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.0.0.tgz#3e2bbfd8bb6724760980988fb5b22b7ee6b71ab2"
+  integrity sha512-ovx/7NkTrnPuIV8sqk/GjUIIM1+iUQeqA3ye2VNpq9sVoiZsooObWlQy+OPWGI17GDaEoybuAGJm6U8yC077BA==
 
 concat-map@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
## Version **7.0.0** of **commander** was just published.

* Package: [repository](https://github.com/tj/commander.js.git), [npm](https://www.npmjs.com/package/commander)
* Current Version: 6.0.0
* Dev: false
* [compare 6.0.0 to 7.0.0 diffs](https://github.com/tj/commander.js/compare/v6.0.0...v7.0.0)

The version(`7.0.0`) is **not covered** by your current version range(`^6.0.0`).

<details>
<summary>Release Notes</summary>
<h1>v7.0.0</h1>
<h3>Added</h3>
<ul>
<li><code>.enablePositionalOptions()</code> to let program and subcommand reuse same option (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1427">#1427</a>)</li>
<li><code>.passThroughOptions()</code> to pass options through to other programs without needing <code>--</code> (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1427">#1427</a>)</li>
<li><code>.allowExcessArguments(false)</code> to show an error message if there are too many command-arguments on command line for the action handler (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1409">#1409</a>)</li>
<li><code>.configureOutput()</code> to modify use of stdout and stderr or customise display of errors (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1387">#1387</a>)</li>
<li>use <code>.addHelpText()</code> to add text before or after the built-in help, for just current command or also for all subcommands (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1296">#1296</a>)</li>
<li>
<p>enhance Option class (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1331">#1331</a>)</p>
<ul>
<li>allow hiding options from help</li>
<li>allow restricting option arguments to a list of choices</li>
<li>allow setting how default value is shown in help</li>
</ul>
</li>
<li><code>.createOption()</code> to support subclassing of automatically created options (like <code>.createCommand()</code>) (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1380">#1380</a>)</li>
<li>
<p>refactor the code generating the help into a separate public Help class (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1365">#1365</a>)</p>
<ul>
<li>support sorting subcommands and options in help</li>
<li>support specifying wrap width (columns)</li>
<li>allow subclassing Help class</li>
<li>allow configuring Help class without subclassing</li>
</ul>
</li>
</ul>
<h3>Changed</h3>
<ul>
<li>
<p><em>Breaking:</em> options are stored safely by default, not as properties on the command (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1409">#1409</a>)</p>
<ul>
<li>this especially affects accessing options on program, use <code>program.opts()</code></li>
<li>revert behaviour with <code>.storeOptionsAsProperties()</code></li>
</ul>
</li>
<li><em>Breaking:</em> action handlers are passed options and command separately (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1409">#1409</a>)</li>
<li>deprecated callback parameter to <code>.help()</code> and <code>.outputHelp()</code> (removed from README) (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1296">#1296</a>)</li>
<li><em>Breaking:</em> errors now displayed using <code>process.stderr.write()</code> instead of <code>console.error()</code></li>
<li>deprecate <code>.on('--help')</code> (removed from README) (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1296">#1296</a>)</li>
<li>initialise the command description to empty string (previously undefined) (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1365">#1365</a>)</li>
<li>document and annotate deprecated routines (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1349">#1349</a>)</li>
</ul>
<h3>Fixed</h3>
<ul>
<li>
<p>wrapping bugs in help (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1365">#1365</a>)</p>
<ul>
<li>first line of command description was wrapping two characters early</li>
<li>pad width calculation was not including help option and help command</li>
<li>pad width calculation was including hidden options and commands</li>
</ul>
</li>
<li>improve backwards compatibility for custom command event listeners (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1403">#1403</a>)</li>
</ul>
<h3>Deleted</h3>
<ul>
<li>
<p><em>Breaking:</em> <code>.passCommandToAction()</code> (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1409">#1409</a>)</p>
<ul>
<li>no longer needed as action handler is passed options and command</li>
</ul>
</li>
<li>
<p><em>Breaking:</em> "extra arguments" parameter to action handler (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1409">#1409</a>)</p>
<ul>
<li>if being used to detect excess arguments, there is now an error available by setting <code>.allowExcessArguments(false)</code></li>
</ul>
</li>
</ul>
<h3>Migration Tips</h3>
<p>The biggest change is the parsed option values. Previously the options were stored by default as properties on the command object, and now the options are stored separately.</p>
<p>If you wish to restore the old behaviour and get running quickly you can call <code>.storeOptionsAsProperties()</code>.
To allow you to move to the new code patterns incrementally, the action handler will be passed the command <em>twice</em>,
to match the new "options" and "command" parameters (see below).</p>
<p><strong>program options</strong></p>
<p>Use the <code>.opts()</code> method to access the options. This is available on any command but is used most with the program.</p>
<pre><code class="language-js">program.option('-d, --debug');
program.parse();
// Old code before Commander 7
if (program.debug) console.log(`Program name is ${program.name()}`);
</code></pre>
<pre><code class="language-js">// New code
const options = program.opts();
if (options.debug) console.log(`Program name is ${program.name()}`);
</code></pre>
<p><strong>action handler</strong></p>
<p>The action handler gets passed a parameter for each command-argument you declared. Previously by default the next parameter was the command object with the options as properties. Now the next two parameters are instead the options and the command. If you
only accessed the options there may be no code changes required.</p>
<pre><code class="language-js">program
  .command('compress &#x3C;filename>')
  .option('-t, --trace')
  // Old code before Commander 7
  .action((filename, cmd)) => {
    if (cmd.trace) console.log(`Command name is ${cmd.name()}`);
  });
</code></pre>
<pre><code class="language-js">  // New code
  .action((filename, options, command)) => {
    if (options.trace) console.log(`Command name is ${command.name()}`);
  });
</code></pre>
<p>If you already set <code>.storeOptionsAsProperties(false)</code> you may still need to adjust your code.</p>
<pre><code class="language-js">program
  .command('compress &#x3C;filename>')
  .storeOptionsAsProperties(false)
  .option('-t, --trace')
  // Old code before Commander 7
  .action((filename, command)) => {
    if (command.opts().trace) console.log(`Command name is ${command.name()}`);
  });
</code></pre>
<pre><code class="language-js">   // New code
   .action((filename, options, command)) => {
      if (command.opts().trace) console.log(`Command name is ${command.name()}`);
   });
</code></pre>

</details>


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: