### PR TITLE
Update commander to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "apng2gif": "^1.7.0",
     "axios": "^0.21.1",
-    "commander": "^7.0.0",
+    "commander": "^8.0.0",
     "fs-extra": "^10.0.0",
     "request": "^2.88.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -378,10 +378,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-7.1.0.tgz#f2eaecf131f10e36e07d894698226e36ae0eb5ff"
-  integrity sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==
+commander@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.0.0.tgz#1da2139548caef59bd23e66d18908dfb54b02258"
+  integrity sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ==
 
 concat-map@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
## Version **8.0.0** of **commander** was just published.

* Package: [repository](https://github.com/tj/commander.js.git), [npm](https://www.npmjs.com/package/commander)
* Current Version: 7.1.0
* Dev: false
* [compare 7.1.0 to 8.0.0 diffs](https://github.com/tj/commander.js/compare/v7.1.0...v8.0.0)

The version(`8.0.0`) is **not covered** by your current version range(`^7.0.0`).

<details>
<summary>Release Notes</summary>
<h1>v8.0.0</h1>
<h3>Added</h3>
<ul>
<li>
<p><code>.argument(name, description)</code> for adding command-arguments (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1490">#1490</a>)</p>
<ul>
<li>supports default value for optional command-arguments (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1508">#1508</a>)</li>
<li>supports custom processing function (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1508">#1508</a>)</li>
</ul>
</li>
<li><code>.createArgument()</code> factory method (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1497">#1497</a>)</li>
<li><code>.addArgument()</code> (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1490">#1490</a>)</li>
<li><code>Argument</code> supports <code>.choices()</code> (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1525">#1525</a>)</li>
<li><code>.showHelpAfterError()</code> to display full help or a custom message after an error (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1534">#1534</a>)</li>
<li><code>.hook()</code> with support for <code>'preAction'</code> and <code>'postAction'</code> callbacks (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1514">#1514</a>)</li>
<li>client typing of <code>.opts()</code> return type using TypeScript generics (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1539">#1539</a>)</li>
<li>the number of command-arguments is checked for programs without an action handler (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1502">#1502</a>)</li>
<li><code>.getOptionValue()</code> and <code>.setOptionValue()</code> (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1521">#1521</a>)</li>
</ul>
<h3>Changed</h3>
<ul>
<li>refactor and simplify TypeScript declarations (with no default export) (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1520">#1520</a>)</li>
<li><code>.parseAsync()</code> is now declared as <code>async</code> (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1513">#1513</a>)</li>
<li><em>Breaking:</em> <code>Help</code> method <code>.visibleArguments()</code> returns array of <code>Argument</code> (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1490">#1490</a>)</li>
<li><em>Breaking:</em> Commander 8 requires Node.js 12 or higher (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1500">#1500</a>)</li>
<li><em>Breaking:</em> <code>CommanderError</code> code <code>commander.invalidOptionArgument</code> renamed <code>commander.invalidArgument</code> (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1508">#1508</a>)</li>
<li><em>Breaking:</em> TypeScript declaration for <code>.addTextHelp()</code> callback no longer allows result of <code>undefined</code>, now just <code>string</code> (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1516">#1516</a>)</li>
<li>refactor <code>index.tab</code> into a file per class (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1522">#1522</a>)</li>
<li>remove help suggestion from "unknown command" error message (see <code>.showHelpAfteError()</code>) (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1534">#1534</a>)</li>
<li><code>Command</code> property <code>.arg</code> initialised to empty array (was previously undefined) (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1529">#1529</a>)</li>
<li>update dependencies</li>
</ul>
<h3>Deprecated</h3>
<ul>
<li>
<p>second parameter of <code>cmd.description(desc, argDescriptions)</code> for adding argument descriptions (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1490">#1490</a>)</p>
<ul>
<li>(use new <code>.argument(name, description)</code> instead)</li>
</ul>
</li>
<li><code>InvalidOptionArgumentError</code> (replaced by <code>InvalidArgumentError</code>) (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1508">#1508</a>)</li>
</ul>
<h3>Removed</h3>
<ul>
<li>
<p><em>Breaking:</em> TypeScript declaration for default export of global <code>Command</code> object (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1520">#1520</a>)</p>
<ul>
<li>(still available as named <code>program</code> export)</li>
</ul>
</li>
</ul>
<h3>Migration Tips</h3>
<p>If you have a simple program without an action handler, you will now get an error if
there are missing command-arguments.</p>
<pre><code class="language-js">program
  .option('-d, --debug')
  .arguments('&#x3C;file>');
program.parse();
</code></pre>
<pre><code class="language-sh">$ node trivial.js 
error: missing required argument 'file'
</code></pre>
<p>If you want to show the help in this situation, you could check the arguments before parsing:</p>
<pre><code class="language-js">if (process.argv.length === 2)
  program.help();
program.parse();
</code></pre>
<p>Or, you might choose to show the help after any user error:</p>
<pre><code class="language-js">program.showHelpAfterError();
</code></pre>

</details>


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: