### PR TITLE
Update axios to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "apng2gif": "^1.7.0",
-    "axios": "^0.21.1",
+    "axios": "^0.22.0",
     "commander": "^8.0.0",
     "fs-extra": "^10.0.0",
     "request": "^2.88.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -281,12 +281,12 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+axios@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.22.0.tgz#bf702c41fb50fbca4539589d839a077117b79b25"
+  integrity sha512-Z0U3uhqQeg1oNcihswf4ZD57O3NrR1+ZXhxaROaWpDmsDTx7T2HNBV2ulBtie2hwJptu8UvgnJoK+BIqdzh/1w==
   dependencies:
-    follow-redirects "^1.10.0"
+    follow-redirects "^1.14.4"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -682,10 +682,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
-follow-redirects@^1.10.0:
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.3.tgz#e5598ad50174c1bc4e872301e82ac2cd97f90267"
-  integrity sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==
+follow-redirects@^1.14.4:
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
+  integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
 
 forever-agent@~0.6.1:
   version "0.6.1"


### PR DESCRIPTION
## Version **0.22.0** of **axios** was just published.

* Package: [repository](https://github.com/axios/axios.git), [npm](https://www.npmjs.com/package/axios)
* Current Version: 0.21.1
* Dev: false
* [compare 0.21.1 to 0.22.0 diffs](https://github.com/axios/axios/compare/v0.21.1...v0.22.0)

The version(`0.22.0`) is **not covered** by your current version range(`^0.21.1`).

<details>
<summary>Release Notes</summary>
<h1>v0.22.0</h1>
<h3>0.22.0 (October 01, 2021)</h3>
<p>Fixes and Functionality:</p>
<ul>
<li>Caseless header comparing in HTTP adapter (<a href="https://github.com/axios/axios/pull/2880">#2880</a>)</li>
<li>Avoid package.json import fixing issues and warnings related to this (<a href="https://github.com/axios/axios/pull/4041">#4041</a>), (<a href="https://github.com/axios/axios/pull/4065">#4065</a>)</li>
<li>Fixed cancelToken leakage and added AbortController support (<a href="https://github.com/axios/axios/pull/3305">#3305</a>)</li>
<li>Updating CI to run on release branches</li>
<li>Bump follow redirects version</li>
<li>Fixed default transitional config for custom Axios instance; (<a href="https://github.com/axios/axios/pull/4052">#4052</a>)</li>
</ul>
<p>Huge thanks to everyone who contributed to this release via code (authors listed below) or via reviews and triaging on GitHub:</p>
<ul>
<li><a href="mailto:jasonsaayman@gmail.com">Jay</a></li>
<li><a href="https://github.com/mastermatt">Matt R. Wilson</a></li>
<li><a href="https://github.com/chinesedfan">Xianming Zhong</a></li>
<li><a href="https://github.com/DigitalBrainJS">Dmitriy Mozgovoy</a></li>
</ul>

</details>


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: