### PR TITLE
Update axios to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "apng2gif": "^1.7.0",
-    "axios": "^0.23.0",
+    "axios": "^0.24.0",
     "commander": "^8.0.0",
     "fs-extra": "^10.0.0",
     "request": "^2.88.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -257,10 +257,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.23.0.tgz#b0fa5d0948a8d1d75e3d5635238b6c4625b05149"
-  integrity sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==
+axios@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
+  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
   dependencies:
     follow-redirects "^1.14.4"
 


### PR DESCRIPTION
## Version **0.24.0** of **axios** was just published.

* Package: [repository](https://github.com/axios/axios.git), [npm](https://www.npmjs.com/package/axios)
* Current Version: 0.23.0
* Dev: false
* [compare 0.23.0 to 0.24.0 diffs](https://github.com/axios/axios/compare/v0.23.0...v0.24.0)

The version(`0.24.0`) is **not covered** by your current version range(`^0.23.0`).

<details>
<summary>Release Notes</summary>
<h1>v0.24.0</h1>
<h3>0.24.0 (October 25, 2021)</h3>
<p>Breaking changes:</p>
<ul>
<li>Revert: change type of AxiosResponse to any, please read lengthy discussion here: (<a href="https://github.com/axios/axios/issues/4141">#4141</a>) pull request: (<a href="https://github.com/axios/axios/pull/4114">#4114</a>)</li>
</ul>
<p>Huge thanks to everyone who contributed to this release via code (authors listed below) or via reviews and triaging on GitHub:</p>
<ul>
<li><a href="mailto:jasonsaayman@gmail.com">Jay</a></li>
<li><a href="https://github.com/ImRodry">Rodry</a></li>
<li><a href="https://github.com/remcohaszing">Remco Haszing</a></li>
<li><a href="https://github.com/ITenthusiasm">Isaiah Thomason</a></li>
</ul>

</details>


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: