### PR TITLE
Update commander to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "apng2gif": "^1.7.0",
     "axios": "^0.25.0",
-    "commander": "^8.0.0",
+    "commander": "^9.0.0",
     "fs-extra": "^10.0.0",
     "request": "^2.88.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -333,10 +333,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-8.0.0.tgz#1da2139548caef59bd23e66d18908dfb54b02258"
-  integrity sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ==
+commander@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.0.0.tgz#86d58f24ee98126568936bd1d3574e0308a99a40"
+  integrity sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==
 
 concat-map@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
## Version **9.0.0** of **commander** was just published.

* Package: [repository](https://github.com/tj/commander.js.git), [npm](https://www.npmjs.com/package/commander)
* Current Version: 8.0.0
* Dev: false
* [compare 8.0.0 to 9.0.0 diffs](https://github.com/tj/commander.js/compare/v8.0.0...v9.0.0)

The version(`9.0.0`) is **not covered** by your current version range(`^8.0.0`).

<details>
<summary>Release Notes</summary>
<h1>v9.0.0</h1>
<h3>Added</h3>
<ul>
<li>simpler ECMAScript import (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1589">#1589</a>)</li>
<li>Option.preset() allows specifying value/arg for option when used without option-argument (especially optional, but also boo
lean option) (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1652">#1652</a>)</li>
<li><code>.executableDir()</code> for custom search for subcommands (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1571">#1571</a>)</li>
<li>throw with helpful message if pass <code>Option</code> to <code>.option()</code> or <code>.requiredOption()</code> (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1655">#1655</a>)</li>
<li>.<code>error()</code> for generating errors from client code just like Commander generated errors, with support for  <code>.configureOutput ()</code>, <code>.exitOverride()</code>, and <code>.showHelpAfterError()</code> (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1675">#1675</a>)</li>
<li><code>.optsWithGlobals()</code> to return merged local and global options (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1671">#1671</a>)</li>
</ul>
<h3>Changed</h3>
<ul>
<li><em>Breaking:</em> Commander 9 requires Node.js v12.20.0 or higher</li>
<li>update package-lock.json to lockfile@2 format (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1659">#1659</a>)</li>
<li><code>showSuggestionAfterError</code> is now on by default (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1657">#1657</a>)</li>
<li><em>Breaking:</em> default value specified for boolean option now always used as default value (see .preset() to match some previo
us behaviours) (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1652">#1652</a>)</li>
<li>default value for boolean option only shown in help if true/false (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1652">#1652</a>)</li>
<li>use command name as prefix for subcommand stand-alone executable name (with fallback to script name for backwards compatibi
lity) (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1571">#1571</a>)</li>
<li>allow absolute path with <code>executableFile</code> (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1571">#1571</a>)</li>
<li>removed restriction that nested subcommands must specify <code>executableFile</code> (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1571">#1571</a>)</li>
<li>TypeScript: allow passing readonly string array to <code>.choices()</code> (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1667">#1667</a>)</li>
<li>TypeScript: allow passing readonly string array to <code>.parse()</code>, <code>.parseAsync()</code>, <code>.aliases()</code> (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1669">#1669</a>)</li>
</ul>
<h3>Fixed</h3>
<ul>
<li>option with optional argument not supplied on command line now works when option already has a value, whether from default
value or from previous arguments (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1652">#1652</a>)</li>
</ul>
<h3>Removed</h3>
<ul>
<li><em>Breaking:</em> removed internal fallback to <code>require.main.filename</code> when script not known from arguments passed to <code>.parse()</code>
(can supply details using <code>.name()</code>, and <code>.executableDir()</code> or <code>executableFile</code>) (<a href="https://github.com/redpeacock78/line-sticker-downloder/issues/1571">#1571</a>)</li>
</ul>

</details>


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: