### PR TITLE
Update axios to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "apng2gif": "^1.7.0",
-    "axios": "^0.25.0",
+    "axios": "^0.26.0",
     "commander": "^9.0.0",
     "fs-extra": "^10.0.0",
     "request": "^2.88.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -257,12 +257,12 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
-  integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
+axios@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.0.tgz#9a318f1c69ec108f8cd5f3c3d390366635e13928"
+  integrity sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==
   dependencies:
-    follow-redirects "^1.14.7"
+    follow-redirects "^1.14.8"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -648,10 +648,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
-follow-redirects@^1.14.7:
-  version "1.14.7"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
-  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
+follow-redirects@^1.14.8:
+  version "1.14.8"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
+  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
 
 forever-agent@~0.6.1:
   version "0.6.1"


### PR DESCRIPTION
## Version **0.26.0** of **axios** was just published.

* Package: [repository](https://github.com/axios/axios.git), [npm](https://www.npmjs.com/package/axios)
* Current Version: 0.25.0
* Dev: false
* [compare 0.25.0 to 0.26.0 diffs](https://github.com/axios/axios/compare/v0.25.0...v0.26.0)

The version(`0.26.0`) is **not covered** by your current version range(`^0.25.0`).

<details>
<summary>Release Notes</summary>
<h1>v0.26.0</h1>
<h3>0.26.0 (February 13, 2022)</h3>
<p>Fixes and Functionality:</p>
<ul>
<li>Fixed The timeoutErrorMessage property in config not work with Node.js (<a href="https://github.com/axios/axios/pull/3581">#3581</a>)</li>
<li>Added errors to be displayed when the query parsing process itself fails (<a href="https://github.com/axios/axios/pull/3961">#3961</a>)</li>
<li>Fix/remove url required (<a href="https://github.com/axios/axios/pull/4426">#4426</a>)</li>
<li>Update follow-redirects dependency due to Vulnerability (<a href="https://github.com/axios/axios/pull/4462">#4462</a>)</li>
<li>Bump karma from 6.3.11 to 6.3.14 (<a href="https://github.com/axios/axios/pull/4461">#4461</a>)</li>
<li>Bump follow-redirects from 1.14.7 to 1.14.8 (<a href="https://github.com/axios/axios/pull/4473">#4473</a>)</li>
</ul>

</details>


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: